### PR TITLE
Add detection for pdftk library.

### DIFF
--- a/spec/pdftk_forms/wrapper_spec.rb
+++ b/spec/pdftk_forms/wrapper_spec.rb
@@ -1,35 +1,41 @@
 require 'spec_helper'
 
 describe PdftkForms::Wrapper do
-  
+
+  context "pdftk_locate" do
+    it "should find the path of pdftk (unstable)" do
+      PdftkForms::Wrapper.path.should == ENV['path']
+    end if ENV['path'] # Give an argument to rake (rake path=/usr/bin/pdftk)
+  end
+
   context "new" do
-    it "should set the default path" do
+    it "should set the path from Wrapper.path" do
       @pdftk = PdftkForms::Wrapper.new
-      @pdftk.path.should == "pdftk"
+      @pdftk.path.should == PdftkForms::Wrapper.path
     end
-    
+
     it "should allow for custom paths" do
-      @pdftk = PdftkForms::Wrapper.new('/usr/local/bin/pdftk')
+      @pdftk = PdftkForms::Wrapper.new(:path => '/usr/local/bin/pdftk')
       @pdftk.path.should == "/usr/local/bin/pdftk"
     end
   end
-  
+
   context "fields" do
     before do
       @pdftk = PdftkForms::Wrapper.new
       @fields = @pdftk.fields(path_to_pdf('fields'))
     end
-    
+
     it "should get the total number of fields" do
       @fields.size.should == 8
     end
-    
+
     it "should return an array of PdftkForms::Field objects" do
       @fields.each do |field|
         field.should be_kind_of(PdftkForms::Field)
       end
     end
-    
+
     it "should set the field data" do
       @fields[0].name.should == "text_not_required"
       @fields[0].value.should == nil
@@ -38,7 +44,7 @@ describe PdftkForms::Wrapper do
       @fields[0].alt_name.should == nil
       @fields[0].options.should == nil
       @fields[0].field_type.should == "text_field"
-      
+
       @fields[1].name.should == "combo_box"
       @fields[1].value.should == nil
       @fields[1].type.should == "Choice"
@@ -46,7 +52,7 @@ describe PdftkForms::Wrapper do
       @fields[1].alt_name.should == nil
       @fields[1].options.should == ["Jason", "Tom"]
       @fields[1].field_type.should == "select"
-      
+
       @fields[2].name.should == "text_required"
       @fields[2].value.should == nil
       @fields[2].type.should == "Text"
@@ -54,7 +60,7 @@ describe PdftkForms::Wrapper do
       @fields[2].alt_name.should == nil
       @fields[2].options.should == nil
       @fields[2].field_type.should == "text_field"
-      
+
       @fields[3].name.should == "check_box"
       @fields[3].value.should == nil
       @fields[3].type.should == "Button"
@@ -62,7 +68,7 @@ describe PdftkForms::Wrapper do
       @fields[3].alt_name.should == nil
       @fields[3].options.should == ["Off", "Yes"]
       @fields[3].field_type.should == "check_box"
-      
+
       @fields[4].name.should == "radio_button"
       @fields[4].value.should == nil
       @fields[4].type.should == "Button"
@@ -70,7 +76,7 @@ describe PdftkForms::Wrapper do
       @fields[4].alt_name.should == nil
       @fields[4].options.should == ["No", "Off", "Yes"]
       @fields[4].field_type.should == "radio_button"
-      
+
       @fields[5].name.should == "list_box"
       @fields[5].value.should == "sam"
       @fields[5].type.should == "Choice"
@@ -78,7 +84,7 @@ describe PdftkForms::Wrapper do
       @fields[5].alt_name.should == nil
       @fields[5].options.should == ["dave", "sam"]
       @fields[5].field_type.should == "select"
-      
+
       @fields[6].name.should == "button"
       @fields[6].value.should == nil
       @fields[6].type.should == "Button"
@@ -86,7 +92,7 @@ describe PdftkForms::Wrapper do
       @fields[6].alt_name.should == nil
       @fields[6].options.should == nil
       @fields[6].field_type.should == "push_button"
-      
+
       @fields[7].name.should == "text_area"
       @fields[7].value.should == nil
       @fields[7].type.should == "Text"
@@ -96,9 +102,10 @@ describe PdftkForms::Wrapper do
       @fields[7].field_type.should == "text_area"
     end
   end
-  
+
   def path_to_pdf(filename)
     File.join File.dirname(__FILE__), '../', 'test_pdfs', "#{filename}.pdf"
   end
-  
+
 end
+


### PR DESCRIPTION
Detection is automatic and non intrusive.

PdftkForms::Wrapper.new #=> use PdftkForms::Wrapper.path
PdftkForms::Wrapper.path #=> use PdftkForms::Wrapper.locate_pdftk & fallback on 'pdftk' in $PATH
You can set a default path, used for all new instances.
PdftkForms::Wrapper.path='my/path' #=> set the default path
Now 
PdftkForms:Wrapper.new #=> will use 'my/path'
but you can always set a specific path on each instance.
PdftkForms::Wrapper.new(:path => 'my/instance/path') => will use 'my/instance/path'

In most of case direct call to `PdftkForms::Wrapper.new` is enough

The project is very young and I decide to change the arguments to PdftkForms:Wrapper.new(options = {})
why : because explicit arguments is always better for non trivial case.
and because PdftkForms::Wrapper.new(nil, bla => bla, bla => blo) is not aestetic !
Fill free to ask to come back.
