### PR TITLE
caches pdftk location at class level

### DIFF
--- a/lib/active_pdftk/call.rb
+++ b/lib/active_pdftk/call.rb
@@ -298,10 +298,16 @@ module ActivePdftk
     #
     # @note Should work on all unix systems (Linux, Mac Os X)
     #
-    def locate_pdftk
+    
+    def self.locate_pdftk
+      return @pdftk_located if @pdftk_located
       auto_path = %x{locate pdftk | grep "/bin/pdftk"}.strip.split("\n").first
       #TODO find a valid Win32 procedure (not in my top priorities)
-      (auto_path.nil? || auto_path.empty?) ? nil : auto_path
+      @pdftk_located = (auto_path.nil? || auto_path.empty?) ? nil : auto_path
+    end
+    
+    def locate_pdftk
+      self.class.locate_pdftk
     end
 
     private

--- a/lib/active_pdftk/call.rb
+++ b/lib/active_pdftk/call.rb
@@ -300,10 +300,11 @@ module ActivePdftk
     #
     
     def self.locate_pdftk
-      return @pdftk_located if @pdftk_located
-      auto_path = %x{locate pdftk | grep "/bin/pdftk"}.strip.split("\n").first
-      #TODO find a valid Win32 procedure (not in my top priorities)
-      @pdftk_located = (auto_path.nil? || auto_path.empty?) ? nil : auto_path
+      @pdftk_location ||= begin
+        auto_path = %x{locate pdftk | grep "/bin/pdftk"}.strip.split("\n").first
+        #TODO find a valid Win32 procedure (not in my top priorities)
+        (auto_path.nil? || auto_path.empty?) ? nil : auto_path
+      end
     end
     
     def locate_pdftk


### PR DESCRIPTION
In no way married to this implementation, but this caches the location of pdftk at the Call class level, reducing the number of calls to locate.  Sped up my spec run from ~55s to ~40s.
