### PR TITLE
Tempdir option

### DIFF
--- a/lib/active_pdftk.rb
+++ b/lib/active_pdftk.rb
@@ -1,3 +1,4 @@
+require 'digest' 
 require 'builder'
 require 'active_pdftk/call'
 require 'active_pdftk/wrapper'

--- a/lib/active_pdftk.rb
+++ b/lib/active_pdftk.rb
@@ -1,4 +1,3 @@
-require 'digest' 
 require 'builder'
 require 'active_pdftk/call'
 require 'active_pdftk/wrapper'

--- a/lib/active_pdftk/call.rb
+++ b/lib/active_pdftk/call.rb
@@ -66,7 +66,8 @@ module ActivePdftk
   #
   # As you know command line programs take often a bunch of arguments, in a very specific syntax. that is our case.
   # In order to call pdftk in a easy way, we build a DSL, it has a hash patern, with four keys : input, operation, output, options.
-  # an additional key +:path+ can be set to specify the path to the pdftk binary.
+  # There are two additional keys. +:path+ can be set to specify the path to the pdftk binary. 
+  # +tmpdir+ can be set to specify the path of the temp directory.
   #   :input => some_input, :operation => some_operation, :output => some_output, :options => some_options
   #
   # ===Input
@@ -184,7 +185,7 @@ module ActivePdftk
       dsl_statements = @default_statements.merge(dsl_statements)
       cmd = "#{@default_statements[:path]} #{set_cmd(dsl_statements)}"
       if dsl_statements[:operation].to_s.match(/burst|unpack_files/)
-        cmd.insert(0, "cd #{Dir.tmpdir} && ")
+        cmd.insert(0, "cd #{tmpdir} && ")
       end
       Open3.popen3(cmd) do |stdin, stdout, stderr|
         if @input
@@ -196,7 +197,7 @@ module ActivePdftk
         raise(CommandError, {:stderr => @error, :cmd => cmd}) unless (@error = stderr.read).empty?
       end
       if dsl_statements[:operation].to_s.match(/burst|unpack_files/) && dsl_statements[:output].nil?
-        Dir.tmpdir
+        tmpdir
       else
         @output
       end
@@ -293,6 +294,14 @@ module ActivePdftk
     #
     def pdftk_version
       %x{#{@default_statements[:path]} --version 2>&1}.scan(/pdftk (\S*) a Handy Tool/).join
+    end
+
+    # Return the directory to use as the temp directory
+    #
+    # @return [String]
+    #
+    def tmpdir
+      @default_statements[:tmpdir] || Dir.tmpdir
     end
 
     # Return the path of the pdftk library if it can be located.

--- a/spec/active_pdftk/call_spec.rb
+++ b/spec/active_pdftk/call_spec.rb
@@ -6,11 +6,16 @@ describe ActivePdftk::Call do
     before :all do
       options = {}
       options[:path] = ENV['path'] unless ENV['path'].nil?
+      options[:tmpdir] = '/custom_temp'
       @pdftk = ActivePdftk::Call.new(options)
     end
 
     it "should set the path (not nil)"do
       @pdftk.default_statements[:path].should_not be_nil
+    end
+
+    it "should set the tmpdir" do
+      @pdftk.default_statements[:tmpdir].should == '/custom_temp'
     end
 
     it "should check the ENV vars" do
@@ -253,6 +258,16 @@ describe ActivePdftk::Call do
       it "should return stringio if no output is specified" do
         @pdftk.pdftk(:input => path_to_pdf('spec.fields.pdf'), :operation => :dump_data).should be_a(StringIO)
       end
+    end
+  end
+
+  context "#tmpdir" do
+    before :all do
+      @pdftk = ActivePdftk::Call.new
+    end
+
+    it "should use the system tmpdir when a tmpdir is not explicity set" do
+      @pdftk.tmpdir.should == Dir.tmpdir
     end
   end
 end

--- a/spec/active_pdftk/wrapper_spec.rb
+++ b/spec/active_pdftk/wrapper_spec.rb
@@ -58,8 +58,8 @@ describe ActivePdftk::Wrapper do
 
     it "should pass the defaults statements to the call instance." do
       path = ActivePdftk::Call.new.locate_pdftk
-      @pdftk_opt = ActivePdftk::Wrapper.new(:path => path, :operation => {:fill_form => 'a.fdf'}, :options => { :flatten => false, :owner_pw => 'bar', :user_pw => 'baz', :encrypt  => :'40bit'})
-      @pdftk_opt.default_statements.should == {:path => path, :operation => {:fill_form => 'a.fdf'}, :options => { :flatten => false, :owner_pw => 'bar', :user_pw => 'baz', :encrypt  => :'40bit'}}
+      @pdftk_opt = ActivePdftk::Wrapper.new(:path => path, :tmpdir => '/other_tmp', :operation => {:fill_form => 'a.fdf'}, :options => { :flatten => false, :owner_pw => 'bar', :user_pw => 'baz', :encrypt  => :'40bit'})
+      @pdftk_opt.default_statements.should == {:path => path, :tmpdir => '/other_tmp', :operation => {:fill_form => 'a.fdf'}, :options => { :flatten => false, :owner_pw => 'bar', :user_pw => 'baz', :encrypt  => :'40bit'}}
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 require File.expand_path('../../lib/active_pdftk', __FILE__)
 
 require 'rspec'
+require 'digest'
 
 Dir[File.expand_path(File.join(File.dirname(__FILE__),'support','**','*.rb'))].each {|f| require f}
 


### PR DESCRIPTION
I needed to add a way to set the tmpdir used during bursts to avoid a race condition where the single pages would be overwritten. I implemented this by allowing users to pass a :tmpdir option. If none is provided, it defaults to Dir.tmpdir, which is what the code was previously using. Please merge this if you think this is a good addition.

Also, note that there is also a commit in this pull request that adds a require for 'digest'. I added this because I got errors when running the tests when digest was not required, so please cherry-pick around this commit if necessary.

And thanks for your work on active_pdftk!
