### PR TITLE
Fixed all non-passing tests in call_spec

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,24 +7,22 @@ PATH
 GEM
   remote: http://rubygems.org/
   specs:
-    builder (3.0.0)
-    diff-lcs (1.1.2)
-    fuubar (0.0.5)
-      rspec (~> 2.0)
-      rspec-instafail (~> 0.1.4)
-      ruby-progressbar (~> 0.0.10)
-    rake (0.8.7)
-    rspec (2.6.0)
-      rspec-core (~> 2.6.0)
-      rspec-expectations (~> 2.6.0)
-      rspec-mocks (~> 2.6.0)
-    rspec-core (2.6.4)
-    rspec-expectations (2.6.0)
-      diff-lcs (~> 1.1.2)
-    rspec-instafail (0.1.8)
-    rspec-mocks (2.6.0)
-    ruby-progressbar (0.0.10)
-    yard (0.7.2)
+    builder (3.2.2)
+    diff-lcs (1.2.5)
+    fuubar (1.3.3)
+      rspec (>= 2.14.0, < 3.1.0)
+      ruby-progressbar (~> 1.4)
+    rake (10.3.2)
+    rspec (2.14.1)
+      rspec-core (~> 2.14.0)
+      rspec-expectations (~> 2.14.0)
+      rspec-mocks (~> 2.14.0)
+    rspec-core (2.14.8)
+    rspec-expectations (2.14.5)
+      diff-lcs (>= 1.1.3, < 2.0)
+    rspec-mocks (2.14.6)
+    ruby-progressbar (1.7.0)
+    yard (0.8.7.6)
 
 PLATFORMS
   ruby
@@ -33,5 +31,5 @@ DEPENDENCIES
   active_pdftk!
   fuubar
   rake (>= 0.8.7)
-  rspec (~> 2.6.0)
+  rspec (~> 2.14.0)
   yard

--- a/active_pdftk.gemspec
+++ b/active_pdftk.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.rubyforge_project = "active_pdftk"
 
   s.add_dependency 'builder', '>= 2.1.2'
-  s.add_development_dependency 'rspec', '~> 2.6.0'
+  s.add_development_dependency 'rspec', '~> 2.14.0'
   s.add_development_dependency 'rake', '>= 0.8.7'
   s.add_development_dependency 'yard'
   s.add_development_dependency 'fuubar'

--- a/spec/active_pdftk/call_spec.rb
+++ b/spec/active_pdftk/call_spec.rb
@@ -183,17 +183,23 @@ describe ActivePdftk::Call do
     end
 
     it "should output without exception and give the appropriate result" do
+      @data_dump_regexp = /^InfoKey:\s(.+)\nInfoValue:\s(.+)/
       @data_string = File.new(path_to_pdf('call/fields.data')).read
+      @data_hash = Hash[@data_string.scan(@data_dump_regexp)]
       
       expect{ @pdftk.pdftk(:input => path_to_pdf('spec.fields.pdf'), :operation => :dump_data, :output => @tempfile) }.to_not raise_error(ActivePdftk::CommandError)
       @tempfile.rewind
-      @tempfile.read.should == @data_string
+      @tempfile_string = @tempfile.read
+      @tempfile_hash = Hash[@tempfile_string.scan(@data_dump_regexp)]
+      @tempfile_hash.should == @data_hash
 
       expect{ @pdftk.pdftk(:input => path_to_pdf('spec.fields.pdf'), :operation => :dump_data, :output => @stringio) }.to_not raise_error(ActivePdftk::CommandError)
-      @stringio.string.should == @data_string
+      @stringio_hash = Hash[@stringio.string.scan(@data_dump_regexp)]
+      @stringio_hash.should == @data_hash
 
-      expect{@return_stringio =  @pdftk.pdftk(:input => path_to_pdf('spec.fields.pdf'), :operation => :dump_data) }.to_not raise_error(ActivePdftk::CommandError)
-      @return_stringio.string.should == @data_string
+      expect{@return_stringio = @pdftk.pdftk(:input => path_to_pdf('spec.fields.pdf'), :operation => :dump_data) }.to_not raise_error(ActivePdftk::CommandError)
+      @return_stringio_hash = Hash[@return_stringio.string.scan(@data_dump_regexp)]
+      @return_stringio_hash.should == @data_hash
     end
 
     it "should input a File, output a StringIO without exception and give the appropriate result" do

--- a/spec/support/inputs_helper.rb
+++ b/spec/support/inputs_helper.rb
@@ -7,7 +7,7 @@ def fixtures_path(entry, expand = false)
   if expand && entry_path.directory?
     entry_path.children
   else
-    entry_path
+    entry_path.to_s
   end
 end
 

--- a/spec/support/matchers/content_matcher.rb
+++ b/spec/support/matchers/content_matcher.rb
@@ -1,3 +1,4 @@
+require 'digest'
 RSpec::Matchers.define :have_the_content_of do |expected|
   match do |actual|
     puts actual.class.name.to_s


### PR DESCRIPTION
The only non-passing tests remaining (though there are admittedly a lot, I think they're all related) are in wrapper_spec.rb.

Partially fixes issue #36. For real this time.
